### PR TITLE
refactor: remove latestAnswer() and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ A Solidity smart contract that simulates a simple decentralized bank with **depo
 The contract enforces a **maximum withdrawal per transaction** expressed in **USD** (8 decimals, compatible with Chainlink).
 
 - **`usdWithdrawalLimit`** (`public immutable`) — withdrawal limit: `1000 USD` (stored as `1000 * 10^8`).
+- **`nativePerTxCapWei`** (`public`) — optional per-transaction wei cap for ETH withdrawals (0 = no limit).
 - When a user calls `withdraw(amount)` (where `amount` is in wei), the contract:
-  1. Gets the ETH/USD price from Chainlink (`latestAnswer()`).
-  2. Converts the `amount` to USD:
+  1. Gets the ETH/USD price from Chainlink using `latestRoundData()` with full oracle validation (staleness check, roundId verification).
+  2. Converts the `amount` to USD with normalized decimals (supports any feed decimals):
     usdValue = (price * amount) / 1e18;
   3. Reverts with `ExceedsUsdLimit` if `usdValue > usdWithdrawalLimit`.
+  4. Reverts with `ExceedsWeiLimit` if wei cap is set and `amount > nativePerTxCapWei`.
 
  This ensures users cannot withdraw more than **$1000 USD** per transaction, regardless of ETH price fluctuations.
 
@@ -28,7 +30,7 @@ This contract uses OpenZeppelin AccessControl and defines two primary roles:
 
 - `ADMIN_ROLE` — role with a narrow, specific power: recover or adjust a user's internal balance when needed. 
     Functions controlled by `ADMIN_ROLE`:
-    - `recoverUserBalance(address account, uint256 newBalanceWei)` — admins can update an account's internal wei balance to help recover funds. This action emits `AdminRecovery` and adjusts the total internal bank balance accordingly.
+    - `recoverUserBalance(address token, address account, uint256 newBalance)` — admins can adjust an account's internal balance for any token (use `ETH_ADDRESS` for native ETH) to help recover funds. This action emits `AdminRecovery` and adjusts the total internal bank balance and USD cache accordingly.
 
 ---
 
@@ -44,12 +46,19 @@ This contract uses OpenZeppelin AccessControl and defines two primary roles:
 
 ## Other Features
 
-- `maxUsdBankCap` (public immutable) — total bank capacity limit in USD with 8 decimals (10,000 USD).
-The deposit() function converts both the incoming deposit and the total balance to USD before accepting new funds.
-- Internal balances are stored in wei (`_balances[address]` and `_kipuBankBalance`) to preserve ETH precision.
-- `getEthPrice()` — returns the current ETH price in USD (8 decimals) using Chainlink.
+- **`maxUsdBankCap`** (public immutable) — total bank capacity limit in USD with 8 decimals (10,000 USD).
+The deposit functions convert both the incoming deposit and the total balance to USD before accepting new funds.
+- **Deposit/Withdraw counters** — `depositCount` and `withdrawCount` track total number of operations.
+- **O(1) total USD tracking** — `_totalBankUsdCache` maintains running total for instant `totalBankUsd()` queries; `recalculateTotalBankUsd()` available for verification.
+- **Oracle hygiene** — all price feeds validated with `latestRoundData()`: checks `answer > 0`, `answeredInRound >= roundId`, and `updatedAt` within 1 hour (MAX_ORACLE_AGE).
+- **Feed decimals normalization** — supports Chainlink feeds with any decimals (8, 18, etc.) via `_normalizePriceTo8Decimals()` helper.
+- **Fee-on-transfer token support** — `depositToken()` uses balance delta to handle tokens with transfer fees correctly.
+- Internal balances are stored in native token units (`_balances[token][account]` and `_tokenTotals[token]`) to preserve precision.
+- `getEthPrice()` — returns the current ETH price in USD (8 decimals) using Chainlink with full validation.
 - `weiToUsd(uint256)` — converts an amount in wei to its equivalent USD value (8 decimals).
-- `getBalanceInUsd(address)` — returns an account’s balance in USD (8 decimals), restricted to the account owner or the bank owner.
+- `tokenAmountToUsd(address, uint256)` — converts any token amount to USD (supports ETH via `ETH_ADDRESS`).
+- `getBalanceInUsd(address token, address account)` — returns an account's token balance in USD (8 decimals), restricted to the account owner or admins.
+- `setNativePerTxCapWei(uint256)` — owner can set/update the per-transaction wei cap for ETH withdrawals.
 
 ---
 
@@ -80,8 +89,8 @@ The deposit() function converts both the incoming deposit and the total balance 
         2. Verify: call `hasRole(ADMIN_ROLE(), targetAddress)` and expect `false`.
     - Testing admin-only recovery:
         1. After granting `ADMIN_ROLE` to an address, switch the active Remix account to that admin address in the top-right account selector.
-        2. Call `recoverUserBalance(address account, uint256 newBalanceWei)` to change a user's internal wei balance.
-        3. Verify the change by calling `getBalance(targetAccount)` or `getBalanceInUsd(targetAccount)`.
+        2. Call `recoverUserBalance(address token, address account, uint256 newBalance)` to change a user's internal balance for a specific token (use `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` for ETH).
+        3. Verify the change by calling `getBalanceOf(token, targetAccount)` or `getBalanceInUsd(token, targetAccount)`.
         4. Try calling `recoverUserBalance` from a non-admin account — it should revert (access denied).
     - Testing owner-only protection:
         1. From a non-owner account, try to call `addAdmin(address)` or `removeAdmin(address)` and confirm the transaction reverts.

--- a/src/KipuBankV2.sol
+++ b/src/KipuBankV2.sol
@@ -6,27 +6,43 @@ import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-
-/// @dev Minimal Chainlink Aggregator interface exposing latestAnswer().
+/// @dev Chainlink Aggregator interface with full roundData support.
 interface AggregatorV3Interface {
-    /// @notice returns the latest price answer.
-    function latestAnswer() external view returns (int256);
+    /// @notice returns the number of decimals for the price feed.
+    function decimals() external view returns (uint8);
+
+    /// @notice returns the latest complete round data.
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
 }
 
-
-contract KipuBank is AccessControl {
+contract KipuBank is AccessControl, ReentrancyGuard {
     using SafeERC20 for IERC20;
-    /// @dev Chainlink price feed (latestAnswer returns price with 8 decimals)
+    /// @dev Chainlink price feed (uses latestRoundData for price with validation)
     AggregatorV3Interface public priceFeed;
 
     /// @dev EIP-7528 canonical placeholder address used to represent ETH when an address is required.
-    address public constant ETH_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+    address public constant ETH_ADDRESS =
+        0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
     /// @dev The maximum USD amount of funds the bank can hold.
     uint256 public immutable maxUsdBankCap = 10000 * 10 ** 8;
     /// @dev The maximum amount of USD that can be withdrawn in a single transaction.
     uint256 public immutable usdWithdrawalLimit = 1000 * 10 ** 8;
+    /// @dev The maximum amount of wei that can be withdrawn in a single native ETH transaction.
+    uint256 public nativePerTxCapWei;
+    /// @dev Maximum age for oracle price data (1 hour).
+    uint256 public constant MAX_ORACLE_AGE = 1 hours;
     /// @dev The address of the contract's owner, set upon deployment.
     address public immutable ownerBank;
     /// @dev Per-token total balances held by the contract (token address -> amount).
@@ -35,13 +51,21 @@ contract KipuBank is AccessControl {
     /// @dev Per-token per-account balances (token => account => amount).
     mapping(address => mapping(address => uint256)) private _balances;
 
+    /// @dev Cached total bank USD value (8 decimals) for O(1) lookups.
+    uint256 private _totalBankUsdCache;
+
+    /// @dev Total number of deposits made to the bank.
+    uint256 public depositCount;
+
+    /// @dev Total number of withdrawals made from the bank.
+    uint256 public withdrawCount;
+
     /// @dev Tracks which tokens are known to the bank (used to compute total USD exposure).
     address[] public trackedTokens;
     mapping(address => bool) private _isTracked;
 
     /// @dev Per-token Chainlink price feed (token address -> Aggregator). For ETH use the `priceFeed` field.
     mapping(address => AggregatorV3Interface) public tokenPriceFeed;
-
 
     /// @notice Error returned when a function is called by an address that is not the bank owner.
     /// @param caller The address that attempted the call.
@@ -59,120 +83,219 @@ contract KipuBank is AccessControl {
     /// @param usdValue The USD value (with 8 decimals) of the attempted withdrawal.
     /// @param limit The configured USD limit (with 8 decimals).
     error ExceedsUsdLimit(uint256 usdValue, uint256 limit);
+    /// @notice Error returned when a withdrawal exceeds the wei limit for native ETH.
+    /// @param weiValue The wei amount of the attempted withdrawal.
+    /// @param limit The configured wei limit.
+    error ExceedsWeiLimit(uint256 weiValue, uint256 limit);
     /// @notice Error returned when the maximum fund limit of the bank is reached.
     /// @param value The amount of funds that exceeds the cap.
     error MaxBankCapReached(uint256 value);
+    /// @notice Error returned when oracle data is stale or invalid.
+    error StalePrice();
     /// @notice Error returned when a user's balance is insufficient for a withdrawal.
     /// @param value The available balance in the account.
     error InsufficientBalance(uint256 value);
     /// @notice Error returned when an Ether or token transfer fails.
     error TransferFailed();
 
-
     /// @dev token is the token address or ETH_ADDRESS for native ETH
-    event SuccessfulDeposit(address indexed account, address indexed token, uint256 amount);
-    event SuccessfulWithdrawal(address indexed account, address indexed token, uint256 amount);
+    event SuccessfulDeposit(
+        address indexed account,
+        address indexed token,
+        uint256 amount,
+        uint256 newBalance,
+        uint256 usdValue
+    );
+    event SuccessfulWithdrawal(
+        address indexed account,
+        address indexed token,
+        uint256 amount,
+        uint256 newBalance,
+        uint256 usdValue
+    );
     event AdminAdded(address indexed account);
     event AdminRemoved(address indexed account);
-    event AdminRecovery(address indexed account, uint256 oldBalance, uint256 newBalance);
+    event AdminRecovery(
+        address indexed account,
+        address indexed token,
+        uint256 oldBalance,
+        uint256 newBalance
+    );
+    event NativeCapUpdated(uint256 oldCap, uint256 newCap);
 
     /// @dev Role identifier for the owner role used as admin for ADMIN_ROLE.
     bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
     /// @dev Role identifier for admins.
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
 
-
     /// @param _priceFeed address of the Chainlink price feed (Sepolia ETH/USD)
     constructor(address _priceFeed) {
         // Initialize price feed first (may be needed to compute defaults)
         if (_priceFeed == address(0)) {
-            priceFeed = AggregatorV3Interface(0x694AA1769357215DE4FAC081bf1f309aDC325306);
+            priceFeed = AggregatorV3Interface(
+                0x694AA1769357215DE4FAC081bf1f309aDC325306
+            );
         } else {
             priceFeed = AggregatorV3Interface(_priceFeed);
         }
 
         // If constructor args are zero, compute defaults using current price
-        // Price has 8 decimals: price = USD * 1e8 per 1 ETH
-        int256 price = priceFeed.latestAnswer();
+        (, int256 price, , , ) = priceFeed.latestRoundData();
         if (price <= 0) {
             revert InvalidPrice(price);
         }
 
-    ownerBank = msg.sender;
+        ownerBank = msg.sender;
 
-    _grantRole(OWNER_ROLE, msg.sender);
-    _grantRole(ADMIN_ROLE, msg.sender);
-    // grant a dedicated OWNER_ROLE to the deployer and make OWNER_ROLE the admin of ADMIN_ROLE
-    _setRoleAdmin(ADMIN_ROLE, OWNER_ROLE);
+        _grantRole(OWNER_ROLE, msg.sender);
+        _grantRole(ADMIN_ROLE, msg.sender);
+        _setRoleAdmin(ADMIN_ROLE, OWNER_ROLE);
+
+        nativePerTxCapWei = 0; // 0 means no limit
     }
 
     /// @notice Deposit native ETH (use EIP-7528 ETH placeholder address in getters/events).
-    function deposit() external payable {
+    function deposit() external payable nonReentrant {
         if (msg.value == 0) revert InvalidValue(msg.value);
 
+        // Checks
         uint256 depositUsd = weiToUsd(msg.value);
-        if (totalBankUsd() + depositUsd > maxUsdBankCap) {
-            revert MaxBankCapReached(maxUsdBankCap - totalBankUsd());
+        if (_totalBankUsdCache + depositUsd > maxUsdBankCap) {
+            revert MaxBankCapReached(maxUsdBankCap - _totalBankUsdCache);
         }
 
+        // Effects
         _balances[ETH_ADDRESS][msg.sender] += msg.value;
         _tokenTotals[ETH_ADDRESS] += msg.value;
+        _totalBankUsdCache += depositUsd;
         _trackTokenIfNeeded(ETH_ADDRESS);
 
-        emit SuccessfulDeposit(msg.sender, ETH_ADDRESS, msg.value);
+        unchecked {
+            depositCount++;
+        }
+
+        emit SuccessfulDeposit(
+            msg.sender,
+            ETH_ADDRESS,
+            msg.value,
+            _balances[ETH_ADDRESS][msg.sender],
+            depositUsd
+        );
     }
 
- 
     /// @notice Withdraw native ETH. `amount` is in wei.
-    function withdraw(uint256 amount) external {
+    function withdraw(uint256 amount) external nonReentrant {
         if (amount == 0) revert InvalidValue(amount);
+
+        // Checks
         uint256 bal = _balances[ETH_ADDRESS][msg.sender];
         if (amount > bal) revert InsufficientBalance(bal);
 
         uint256 usdValue = weiToUsd(amount);
-        if (usdValue > usdWithdrawalLimit) revert ExceedsUsdLimit(usdValue, usdWithdrawalLimit);
+        if (usdValue > usdWithdrawalLimit)
+            revert ExceedsUsdLimit(usdValue, usdWithdrawalLimit);
 
+        // Check native wei cap if set
+        if (nativePerTxCapWei != 0 && amount > nativePerTxCapWei) {
+            revert ExceedsWeiLimit(amount, nativePerTxCapWei);
+        }
+
+        // Effects
         _balances[ETH_ADDRESS][msg.sender] = bal - amount;
         _tokenTotals[ETH_ADDRESS] -= amount;
+        _totalBankUsdCache -= usdValue;
 
+        unchecked {
+            withdrawCount++;
+        }
+
+        // Interactions
         (bool success, ) = payable(msg.sender).call{value: amount}("");
         if (!success) revert TransferFailed();
 
-        emit SuccessfulWithdrawal(msg.sender, ETH_ADDRESS, amount);
+        emit SuccessfulWithdrawal(
+            msg.sender,
+            ETH_ADDRESS,
+            amount,
+            _balances[ETH_ADDRESS][msg.sender],
+            usdValue
+        );
     }
 
     /// @notice Deposit ERC20 token. Caller must `approve` this contract beforehand.
-    function depositToken(address token, uint256 amount) external {
+    function depositToken(address token, uint256 amount) external nonReentrant {
         if (amount == 0) revert InvalidValue(amount);
-        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
 
+        // Checks - verify cap BEFORE transferring tokens (CEI pattern)
         uint256 depositUsd = tokenAmountToUsd(token, amount);
-        if (totalBankUsd() + depositUsd > maxUsdBankCap) {
-            revert MaxBankCapReached(maxUsdBankCap - totalBankUsd());
+        if (_totalBankUsdCache + depositUsd > maxUsdBankCap) {
+            revert MaxBankCapReached(maxUsdBankCap - _totalBankUsdCache);
         }
 
-        _balances[token][msg.sender] += amount;
-        _tokenTotals[token] += amount;
+        // Effects - measure actual received amount (handles fee-on-transfer tokens)
+        uint256 balanceBefore = IERC20(token).balanceOf(address(this));
+
+        // Interactions - transfer tokens LAST
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+
+        uint256 received = IERC20(token).balanceOf(address(this)) -
+            balanceBefore;
+
+        // Recalculate USD based on actual received amount
+        uint256 actualDepositUsd = tokenAmountToUsd(token, received);
+
+        _balances[token][msg.sender] += received;
+        _tokenTotals[token] += received;
+        _totalBankUsdCache += actualDepositUsd;
         _trackTokenIfNeeded(token);
 
-        emit SuccessfulDeposit(msg.sender, token, amount);
+        unchecked {
+            depositCount++;
+        }
+
+        emit SuccessfulDeposit(
+            msg.sender,
+            token,
+            received,
+            _balances[token][msg.sender],
+            actualDepositUsd
+        );
     }
 
     /// @notice Withdraw ERC20 token previously deposited.
-    function withdrawToken(address token, uint256 amount) external {
+    function withdrawToken(
+        address token,
+        uint256 amount
+    ) external nonReentrant {
         if (amount == 0) revert InvalidValue(amount);
+
+        // Checks
         uint256 bal = _balances[token][msg.sender];
         if (amount > bal) revert InsufficientBalance(bal);
 
         uint256 usdValue = tokenAmountToUsd(token, amount);
-        if (usdValue > usdWithdrawalLimit) revert ExceedsUsdLimit(usdValue, usdWithdrawalLimit);
+        if (usdValue > usdWithdrawalLimit)
+            revert ExceedsUsdLimit(usdValue, usdWithdrawalLimit);
 
+        // Effects
         _balances[token][msg.sender] = bal - amount;
         _tokenTotals[token] -= amount;
+        _totalBankUsdCache -= usdValue;
 
-    IERC20(token).safeTransfer(msg.sender, amount);
+        unchecked {
+            withdrawCount++;
+        }
 
-        emit SuccessfulWithdrawal(msg.sender, token, amount);
+        // Interactions
+        IERC20(token).safeTransfer(msg.sender, amount);
+
+        emit SuccessfulWithdrawal(
+            msg.sender,
+            token,
+            amount,
+            _balances[token][msg.sender],
+            usdValue
+        );
     }
 
     /// @dev A modifier that restricts a function's execution to accounts with OWNER_ROLE.
@@ -185,7 +308,15 @@ contract KipuBank is AccessControl {
 
     function currentBalance() external view onlyOwner returns (uint256) {
         // return the bank total balance expressed in USD with 8 decimals
-        return totalBankUsd();
+        return _totalBankUsdCache;
+    }
+
+    /// @notice Owner-only: set the native per-transaction wei cap for ETH withdrawals.
+    /// @param cap The new cap in wei (0 means no limit).
+    function setNativePerTxCapWei(uint256 cap) external onlyOwner {
+        uint256 oldCap = nativePerTxCapWei;
+        nativePerTxCapWei = cap;
+        emit NativeCapUpdated(oldCap, cap);
     }
 
     /// @dev A modifier that restricts a function's execution to the account owner or any account with ADMIN_ROLE.
@@ -197,12 +328,22 @@ contract KipuBank is AccessControl {
     }
 
     /// @notice Returns the ETH balance (wei) for `account`.
-    function getBalance(address account) external view onlyAccountOwnerOrAdmin(ETH_ADDRESS, account) returns (uint256) {
+    function getBalance(
+        address account
+    )
+        external
+        view
+        onlyAccountOwnerOrAdmin(ETH_ADDRESS, account)
+        returns (uint256)
+    {
         return _balances[ETH_ADDRESS][account];
     }
 
     /// @notice Returns the token balance for `account` and `token`.
-    function getBalanceOf(address token, address account) external view onlyAccountOwnerOrAdmin(token, account) returns (uint256) {
+    function getBalanceOf(
+        address token,
+        address account
+    ) external view onlyAccountOwnerOrAdmin(token, account) returns (uint256) {
         return _balances[token][account];
     }
 
@@ -219,80 +360,135 @@ contract KipuBank is AccessControl {
     }
 
     /// @notice Admins can adjust a user's token balance to help recover funds. Token may be ETH_ADDRESS for native ETH.
-    function recoverUserBalance(address token, address account, uint256 newBalance) external onlyRole(ADMIN_ROLE) {
+    function recoverUserBalance(
+        address token,
+        address account,
+        uint256 newBalance
+    ) external onlyRole(ADMIN_ROLE) {
         uint256 old = _balances[token][account];
         if (newBalance > old) {
             uint256 delta = newBalance - old;
+            uint256 deltaUsd = tokenAmountToUsd(token, delta);
             _balances[token][account] = newBalance;
             _tokenTotals[token] += delta;
+            _totalBankUsdCache += deltaUsd;
         } else if (newBalance < old) {
             uint256 delta = old - newBalance;
+            uint256 deltaUsd = tokenAmountToUsd(token, delta);
             _balances[token][account] = newBalance;
             _tokenTotals[token] -= delta;
+            _totalBankUsdCache -= deltaUsd;
         } else {
             return;
         }
 
         // Ensure bank cap is not violated after recovery
-        if (totalBankUsd() > maxUsdBankCap) {
-            revert MaxBankCapReached(maxUsdBankCap - totalBankUsd());
+        if (_totalBankUsdCache > maxUsdBankCap) {
+            revert MaxBankCapReached(maxUsdBankCap - _totalBankUsdCache);
         }
 
-        emit AdminRecovery(account, old, newBalance);
+        emit AdminRecovery(account, token, old, newBalance);
     }
 
-    /// @notice Returns the latest ETH price in USD with 8 decimals (reverts if price <= 0).
+    /// @notice Returns the latest ETH price in USD with 8 decimals (reverts if price <= 0 or stale).
     function getEthPrice() public view returns (uint256) {
-        int256 price = priceFeed.latestAnswer();
-        if (price <= 0) {
-            revert InvalidPrice(price);
-        }
-        return uint256(price);
+        (
+            uint80 roundId,
+            int256 answer,
+            ,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        ) = priceFeed.latestRoundData();
+
+        if (answer <= 0) revert InvalidPrice(answer);
+        if (answeredInRound < roundId) revert StalePrice();
+        if (block.timestamp - updatedAt > MAX_ORACLE_AGE) revert StalePrice();
+
+        // Normalize to 8 decimals
+        uint8 feedDecimals = _getFeedDecimals(priceFeed);
+        return _normalizePriceTo8Decimals(uint256(answer), feedDecimals);
     }
 
     /// @notice Convert an amount in wei to USD with 8 decimals using the Chainlink feed.
     /// @param amountWei amount in wei
     /// @return usdValue USD value with 8 decimals
-    function weiToUsd(uint256 amountWei) public view returns (uint256 usdValue) {
+    function weiToUsd(
+        uint256 amountWei
+    ) public view returns (uint256 usdValue) {
         uint256 price = getEthPrice();
         // usd = price(8dec) * wei / 1e18 -> result has 8 decimals
         usdValue = (price * amountWei) / 1e18;
     }
 
     /// @notice Convert token amount to USD (8 decimals). For ETH use `ETH_ADDRESS` and pass wei amount.
-    function tokenAmountToUsd(address token, uint256 amount) public view returns (uint256) {
+    function tokenAmountToUsd(
+        address token,
+        uint256 amount
+    ) public view returns (uint256) {
         if (token == ETH_ADDRESS) {
             return weiToUsd(amount);
         }
         AggregatorV3Interface feed = tokenPriceFeed[token];
         if (address(feed) == address(0)) revert InvalidPrice(0);
-        int256 price = feed.latestAnswer();
-        if (price <= 0) revert InvalidPrice(price);
 
-        uint8 decimals = 18;
+        (
+            uint80 roundId,
+            int256 answer,
+            ,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        ) = feed.latestRoundData();
+
+        if (answer <= 0) revert InvalidPrice(answer);
+        if (answeredInRound < roundId) revert StalePrice();
+        if (block.timestamp - updatedAt > MAX_ORACLE_AGE) revert StalePrice();
+
+        uint8 tokenDecimals = 18;
         // try to read token decimals if available
         try IERC20Metadata(token).decimals() returns (uint8 d) {
-            decimals = d;
+            tokenDecimals = d;
         } catch {
-            decimals = 18; // fallback
+            tokenDecimals = 18; // fallback
         }
 
-        // price has 8 decimals and amount has `decimals` decimals -> usd = price * amount / (10**decimals)
-        return (uint256(price) * amount) / (10 ** decimals);
+        // Normalize price to 8 decimals
+        uint8 feedDecimals = _getFeedDecimals(feed);
+        uint256 priceUsd8 = _normalizePriceTo8Decimals(
+            uint256(answer),
+            feedDecimals
+        );
+
+        // usd (8 decimals) = price (8 decimals) * amount (token decimals) / (10**token decimals)
+        return (priceUsd8 * amount) / (10 ** tokenDecimals);
     }
 
-    /// @notice Returns total bank USD exposure summing all tracked tokens (8 decimals)
-    function totalBankUsd() public view returns (uint256 totalUsd) {
+    /// @notice Returns total bank USD exposure (8 decimals) - now O(1) using cache.
+    function totalBankUsd() public view returns (uint256) {
+        return _totalBankUsdCache;
+    }
+
+    /// @notice Recalculates total bank USD from scratch (for verification/emergency).
+    /// @dev This is the O(n) version, kept for admin verification purposes.
+    function recalculateTotalBankUsd()
+        external
+        onlyOwner
+        returns (uint256 totalUsd)
+    {
         for (uint256 i = 0; i < trackedTokens.length; i++) {
             address t = trackedTokens[i];
             uint256 tot = _tokenTotals[t];
             if (tot == 0) continue;
             totalUsd += tokenAmountToUsd(t, tot);
         }
+        _totalBankUsdCache = totalUsd;
+        return totalUsd;
     }
 
     /// @notice Owner can set a price feed for arbitrary tokens (token address -> aggregator).
-    function setTokenPriceFeed(address token, address aggregator) external onlyOwner {
+    function setTokenPriceFeed(
+        address token,
+        address aggregator
+    ) external onlyOwner {
         tokenPriceFeed[token] = AggregatorV3Interface(aggregator);
         _trackTokenIfNeeded(token);
     }
@@ -305,7 +501,40 @@ contract KipuBank is AccessControl {
     }
 
     /// @notice Returns the USD value (8 decimals) of an account's internal balance for a given token. Restricted to account or admin.
-    function getBalanceInUsd(address token, address account) external view onlyAccountOwnerOrAdmin(token, account) returns (uint256) {
+    function getBalanceInUsd(
+        address token,
+        address account
+    ) external view onlyAccountOwnerOrAdmin(token, account) returns (uint256) {
         return tokenAmountToUsd(token, _balances[token][account]);
+    }
+
+    /// @dev Internal helper to get feed decimals safely.
+    /// @param feed The Chainlink price feed.
+    /// @return The number of decimals (defaults to 8 if call fails).
+    function _getFeedDecimals(
+        AggregatorV3Interface feed
+    ) internal view returns (uint8) {
+        try feed.decimals() returns (uint8 d) {
+            return d;
+        } catch {
+            return 8; // Default to 8 decimals (Chainlink standard)
+        }
+    }
+
+    /// @dev Internal helper to normalize price feed decimals to 8 decimals.
+    /// @param price The raw price from the feed.
+    /// @param feedDecimals The number of decimals the feed uses.
+    /// @return The price normalized to 8 decimals.
+    function _normalizePriceTo8Decimals(
+        uint256 price,
+        uint8 feedDecimals
+    ) internal pure returns (uint256) {
+        if (feedDecimals == 8) {
+            return price;
+        } else if (feedDecimals < 8) {
+            return price * (10 ** (8 - feedDecimals));
+        } else {
+            return price / (10 ** (feedDecimals - 8));
+        }
     }
 }


### PR DESCRIPTION
- Remove latestAnswer() function from AggregatorV3Interface
- Contract already uses latestRoundData() with full validation
- Update README to reflect current implementation:
  - Add nativePerTxCapWei documentation
  - Add deposit/withdraw counters
  - Add O(1) totalBankUsd cache explanation
  - Add oracle hygiene validations
  - Add feed decimals normalization
  - Update recoverUserBalance signature with token parameter
  - Fix function references and examples